### PR TITLE
Deployment / Config updates

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,1 +1,4 @@
+auth
+workspace_deluxe
+kbapi_common
 kb_sdk

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ compile-kb-module:
 build-executable-script-python: setup-local-dev-kb-py-libs
 	mkdir -p $(LBIN_DIR)
 	echo '#!/bin/bash' > $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
+	echo 'export KB_DEPLOYMENT_CONFIG="$(DIR)/deploy.cfg"' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
+	echo 'export KB_SERVICE_NAME="$(MODULE_CAPS)"' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'export PYTHONPATH="$(DIR)/$(LIB_DIR)"' >> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'python $(DIR)/lib/biokbase/$(MODULE)/$(MODULE_CAPS).py $$1 $$2 $$3' \
 		>> $(LBIN_DIR)/$(EXECUTABLE_SCRIPT_NAME)
@@ -72,20 +74,24 @@ DEPLOY_RUNTIME ?= /kb/runtime
 TARGET ?= /kb/deployment
 #SERVICE_DIR ?= $(TARGET)/services/$(MODULE)
 
-deploy: deploy-scripts
+deploy: deploy-scripts deploy-cfg
 
-deploy-scripts: deploy-libs deploy-executable-script
+deploy-client: deploy-scripts deploy-cfg
+
+deploy-scripts: deploy-libs deploy-executable-script deploy-cfg
 
 deploy-service: deploy-libs deploy-executable-script deploy-service-scripts deploy-cfg
 
 deploy-libs:
 	@echo "Deploying libs to target: $(TARGET)"
 	mkdir -p $(TARGET)/lib/biokbase
-	rsync -vrh lib/biokbase/$(MODULE) $(TARGET)/lib/biokbase/.
+	rsync -vrh --exclude *.bak* lib/biokbase/$(MODULE) $(TARGET)/lib/biokbase/.
 
 deploy-executable-script:
 	@echo "Installing executable scripts to target: $(TARGET)/bin"
 	echo '#!/bin/bash' > $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
+	echo 'export KB_DEPLOYMENT_CONFIG="$(TARGET)/deployment.cfg"' >> $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
+	echo 'export KB_SERVICE_NAME="$(MODULE_CAPS)"' >> $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'export KB_RUNTIME=$(DEPLOY_RUNTIME)' >> $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'export PYTHONPATH="$(TARGET)/lib"' >> $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'python $(TARGET)/lib/biokbase/$(MODULE)/$(MODULE_CAPS).py $$1 $$2 $$3' \
@@ -104,7 +110,7 @@ test-impl: create-test-wrapper
 create-test-wrapper:
 	@echo "Creating test script wrapper in test/script_test"
 	echo '#!/bin/bash' > test/script_test/run_tests.sh
-	echo 'export PYTHONPATH="$(DIR)/$(LIB_DIR)"' >> test/script_test/run_tests.sh
+	echo 'export KB_RUNTIME=$(DEPLOY_RUNTIME)' >> $(TARGET)/bin/$(EXECUTABLE_SCRIPT_NAME)
 	echo 'export PYTHONPATH="$(DIR)/$(LIB_DIR)"' >> test/script_test/run_tests.sh
 	echo 'python $(DIR)/test/script_test/basic_test.py $$1 $$2 $$3' \
 		>> test/script_test/run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ setup-local-dev-kb-py-libs:
 	touch lib/biokbase/$(MODULE)/__init__.py
 	rsync -vrh ../kbapi_common/lib/biokbase/* lib/biokbase/.
 	rsync -vrh ../auth/lib/biokbase/* lib/biokbase/.
+	rsync -vrh ../workspace_deluxe/lib/biokbase/* lib/biokbase/.
 	#	--exclude TestMathClient.pl --exclude TestPerlServer.sh \
 	#	--exclude *.bak* --exclude AuthConstants.pm
 

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -1,0 +1,5 @@
+
+
+[KBaseGenomeUtil]
+ws_url=https://ci.kbase.us/services/ws
+temp_dir=temp_dir

--- a/lib/biokbase/genome_util/KBaseGenomeUtilImpl.py
+++ b/lib/biokbase/genome_util/KBaseGenomeUtilImpl.py
@@ -4,6 +4,7 @@ import sys
 import os
 import glob
 import json
+from pprint import pprint
 #sys.path.insert(0, '/kb/dev_container/modules/genome_util/lib/biokbase/genome_util')
 import script_util
 #from biokbase.workspace.client import Workspace
@@ -29,12 +30,26 @@ class KBaseGenomeUtil:
     # the latter method is running.
     #########################################
     #BEGIN_CLASS_HEADER
+    # Config variables that SHOULD get overwritten in the constructor
+    __TEMP_DIR = 'temp_dir'
+    __WS_URL = 'https://kbase.us/services/ws'
     #END_CLASS_HEADER
 
     # config contains contents of config file in a hash or None if it couldn't
     # be found
     def __init__(self, config):
         #BEGIN_CONSTRUCTOR
+
+        # This is where config variable for deploy.cfg are available
+        print "SCRIPT CONFIG:"
+        pprint(config)
+        if 'ws_url' in config:
+        	__WS_URL = config['ws_url']
+        	print "Setting __WS_URL = "+__WS_URL
+        if 'temp_dir' in config:
+        	__TEMP_DIR = config['temp_dir']
+        	print "Setting __TEMP_DIR = "+__TEMP_DIR
+
         #END_CONSTRUCTOR
         pass
 

--- a/test/script_test/basic_test.py
+++ b/test/script_test/basic_test.py
@@ -1,25 +1,39 @@
-
+# Test script for genome_util package - it should be launched from
+# the root of the genome_util module, ideally just with 'make test', as
+# it looks for a hardcoded relative path to find the 'test.cfg' file
 import unittest
 import json
+import ConfigParser
 
 from pprint import pprint
 
 from subprocess import call
 
-class TestGenomeUtilMethods(unittest.TestCase):
+from biokbase.auth import Token
+
+# Before all the tests, read the config file and get a user token and
+# save it to a file used by the main service script
+class TestGenomeUtilMethodsSetup(unittest.TestCase):
+  def setUp(self):
+    config = ConfigParser.RawConfigParser()
+    config.read('test/test.cfg')
+    user_id = config.get('GenomeUtilTest','user')
+    password = config.get('GenomeUtilTest','password')
+    token = Token(user_id=user_id, password=password)
+    token_file = open('test/script_test/token.txt','w')
+    token_file.write(token.token)
+
+# Define all our other test cases here
+class TestGenomeUtilMethods(TestGenomeUtilMethodsSetup):
 
   def test_method(self):
     print("\n\n----------- basic test ----------")
-
-    # write the 
-
-
 
     # call the script with some input
     out = call(["run_KBaseGenomeUtil.sh", 
        "test/script_test/input.json", 
        "test/script_test/output.json", 
-       "/mnt/project/mytoken.txt"])
+       "test/script_test/token.txt"])
 
     # print error code of implementation
     print(out);
@@ -30,6 +44,6 @@ class TestGenomeUtilMethods(unittest.TestCase):
     pprint(output)
 
 
-
+# start the tests if run as a script
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.cfg
+++ b/test/test.cfg
@@ -1,0 +1,5 @@
+
+[GenomeUtilTest]
+
+user=[kbase_user_name]
+password=[password]


### PR DESCRIPTION
I updated a few things to make the deployment and configuration setup better.  I think this will solve problems you had with the python path, and help get things deployed properly in CI.

First, I added additional dependencies to the DEPENDENCIES file and copied over the workspace client libs when setting up the python dev_container environment, so the script should be able to see the WS python libs in the dev_container.  You shouldn't have to manually modify the PYTHON_PATH variable anymore to point to deployment.

Second, I updated the tests to read a test/test.cfg file that takes a user name and password (instead of a token directly).  The tests should read that file and get the token for you.  You can add additional test options there if needed.  You should update the parameters for tests, but you should not commit any changes to that file.

Finally, I setup the deploy.cfg file and deployment of that file.  You'll see in the implementation file that the deployment variables are read into class variables which are then available for all the other methods.  For now, I loaded the workspace url (which should always be a parameter) and a temporary directory path.  Feel free to change the names or add more options.

When running the main script from dev_container, the makefile is setup so that script generated will read the local deploy.cfg file in genome_util.  When running the main script deployed to say /kb/deployment, the script will use /kb/deployment/deployment.cfg.  On 'make deploy' /kb/deployment/deployment.cfg will be updated.

Let me know if you have questions.  Thanks.
